### PR TITLE
fix: create parent recording directories if necessary

### DIFF
--- a/internal/webrtc/recorder/recorder.go
+++ b/internal/webrtc/recorder/recorder.go
@@ -32,6 +32,22 @@ func NewRecorder(ctx context.Context, cfg config.Recorder, file string, fn FlowC
 	}
 
 	file = path.Clean(dir + string(os.PathSeparator) + file)
+	fileDir := path.Dir(file)
+
+	if stat, err := os.Stat(fileDir); err != nil {
+		log.WithField("session", ctx.Value("session")).
+			Debug(stat)
+
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("file directory is not accessible %s", fileDir)
+		}
+
+		err = os.MkdirAll(fileDir, 0700)
+		if err != nil && !os.IsExist(err) {
+			return nil, fmt.Errorf("file directory could not be created %s", fileDir)
+		}
+	}
+
 	if stat, err := os.Stat(file); !os.IsNotExist(err) {
 		log.WithField("session", ctx.Value("session")).
 			Debug(stat)


### PR DESCRIPTION
This app expects the file name to be the base path - ie all files go into the root of the recording folder specified in the config. That makes things a bit difficult because BBB records files in different hierarchies, so parent dirs up to recorder.directory need to be flexible somehow. Those extra directories are created on demand based on server-provided data generated on the fly (basically the meetingID). An example of that flexible structure:
  - For cameras, recordings should be in /var/lib/bbb-webrtc-recorder/recordings/<meetingID>/<fileName>.webm
  - For screens, recordings should be in /var/lib/bbb-webrtc-recorder/screenshare/<meetingID><fileName>.webm

This commit checks whether the parent directories up recorder.directory are present and try to create them if they aren't. It errors out in case that fails.


cc @arthurpro 